### PR TITLE
fix: reorder inline styles to stop it splitting on links

### DIFF
--- a/packages/language-markdown/src/markdown/MarkdownSerializer.ts
+++ b/packages/language-markdown/src/markdown/MarkdownSerializer.ts
@@ -32,8 +32,8 @@ export function createMarkdownSerializer(options: StandardToolOptions): any {
           ...TextToMarkdown
         },
         {
-          ...markdown.defaultMarkdownSerializer.marks,
-          ...InlineStylesToMarkdown
+          ...InlineStylesToMarkdown,
+          ...markdown.defaultMarkdownSerializer.marks
         }
       );
 }

--- a/packages/language-markdown/src/schema/createSchema.ts
+++ b/packages/language-markdown/src/schema/createSchema.ts
@@ -18,7 +18,7 @@ export function createSchema(options: StandardToolOptions, isInlineStylesEnabled
   // TODO: don't register nodes and marks that are disabled in the options
   let marks = schema.spec.marks;
   if (isInlineStylesEnabled) {
-    marks = marks.addToEnd("inline_styles", inline_styles);
+    marks = marks.addToStart("inline_styles", inline_styles);
   }
 
   const nodes = schema.spec.nodes.append(tableNodes({


### PR DESCRIPTION
This should fix serialization issues like the following:

`<span class="red">te[sti](http://google.com)ng</span>`
would serialize to
`<span class="red">te</span>[<span class="red">sti</span>](http://google.com)<span class="red">ng</span>`